### PR TITLE
Fix search3 starred album lookup

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/repository/AlbumRepository.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/repository/AlbumRepository.java
@@ -43,8 +43,6 @@ public interface AlbumRepository extends JpaRepository<Album, Integer> {
 
     public List<Album> findByPresentFalse();
 
-    public Optional<Album> findByIdAndStarredAlbumsUsername(Integer id, String username);
-
     public boolean existsByLastScannedBeforeAndPresentTrue(Instant lastScanned);
 
     @Transactional

--- a/airsonic-main/src/main/java/org/airsonic/player/repository/StarredAlbumRepository.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/repository/StarredAlbumRepository.java
@@ -21,6 +21,8 @@ public interface StarredAlbumRepository extends JpaRepository<StarredAlbum, Inte
 
     public Optional<StarredAlbum> findByAlbumAndUsername(Album album, String username);
 
+    public Optional<StarredAlbum> findByAlbumIdAndUsername(Integer albumId, String username);
+
     @Transactional
     public void deleteByAlbumAndUsername(Album album, String username);
 

--- a/airsonic-main/src/main/java/org/airsonic/player/service/AlbumService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/AlbumService.java
@@ -281,8 +281,8 @@ public class AlbumService {
         if (albumId == null || !StringUtils.hasLength(username)) {
             return null;
         }
-        return albumRepository.findByIdAndStarredAlbumsUsername(albumId, username)
-                .map(album -> album.getStarredAlbums().isEmpty() ? null : album.getStarredAlbums().get(0).getCreated())
+        return starredAlbumRepository.findByAlbumIdAndUsername(albumId, username)
+                .map(StarredAlbum::getCreated)
                 .orElse(null);
     }
 

--- a/airsonic-main/src/test/java/org/airsonic/player/repository/AlbumRepositoryTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/repository/AlbumRepositoryTest.java
@@ -242,7 +242,7 @@ public class AlbumRepositoryTest {
         }
 
         @Test
-        public void testFindByIdAndStarredAlbumsUsername() {
+        public void testFindByAlbumIdAndUsername() {
 
             Album album1 = new Album("path1", "name1", "artist1", Instant.now(), Instant.now(), true, testFolders.get(0));
             Album album2 = new Album("path2", "name2", "artist1", Instant.now(), Instant.now(), false, testFolders.get(1));
@@ -250,20 +250,22 @@ public class AlbumRepositoryTest {
             albumRepository.saveAndFlush(album1);
             albumRepository.saveAndFlush(album2);
 
-            StarredAlbum starredAlbum1 = new StarredAlbum(album1, TEST_USER_NAME, Instant.now());
+            Instant created = Instant.now();
+            StarredAlbum starredAlbum1 = new StarredAlbum(album1, TEST_USER_NAME, created);
             StarredAlbum starredAlbum2 = new StarredAlbum(album2, TEST_USER_NAME2, Instant.now());
 
             starredAlbumRepository.saveAndFlush(starredAlbum1);
             starredAlbumRepository.saveAndFlush(starredAlbum2);
 
-            Album result = albumRepository.findByIdAndStarredAlbumsUsername(album1.getId(), TEST_USER_NAME).get();
-            assertEquals(album1, result);
+            StarredAlbum result = starredAlbumRepository.findByAlbumIdAndUsername(album1.getId(), TEST_USER_NAME).get();
+            assertEquals(starredAlbum1, result);
+            assertEquals(created, result.getCreated());
 
-            Album result2 = albumRepository.findByIdAndStarredAlbumsUsername(album2.getId(), TEST_USER_NAME)
+            StarredAlbum result2 = starredAlbumRepository.findByAlbumIdAndUsername(album2.getId(), TEST_USER_NAME)
                     .orElse(null);
             assertNull(result2);
 
-            Album result3 = albumRepository.findByIdAndStarredAlbumsUsername(album1.getId(), TEST_USER_NAME2)
+            StarredAlbum result3 = starredAlbumRepository.findByAlbumIdAndUsername(album1.getId(), TEST_USER_NAME2)
                     .orElse(null);
             assertNull(result3);
 

--- a/airsonic-main/src/test/java/org/airsonic/player/service/AlbumServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/AlbumServiceTest.java
@@ -35,6 +35,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Sort;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -208,6 +209,40 @@ public class AlbumServiceTest {
         assertEquals(Sort.Direction.DESC, actualPageRequest.getSort().getOrderFor("created").getDirection());
         assertEquals(Sort.Direction.ASC, actualPageRequest.getSort().getOrderFor("albumId").getDirection());
 
+    }
+
+    @Test
+    public void testGetAlbumStarredDate() {
+
+        // given
+        Instant created = Instant.parse("2026-06-27T10:57:10Z");
+        Album album = new Album();
+        album.setId(1);
+        StarredAlbum starredAlbum = new StarredAlbum(album, "username", created);
+        when(starredAlbumRepository.findByAlbumIdAndUsername(1, "username")).thenReturn(Optional.of(starredAlbum));
+
+        // when
+        Instant actual = albumService.getAlbumStarredDate(1, "username");
+
+        // then
+        assertEquals(created, actual);
+        verify(starredAlbumRepository).findByAlbumIdAndUsername(1, "username");
+        verifyNoInteractions(albumRepository);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        ",username",
+        "1,",
+    })
+    public void testGetAlbumStarredDateShouldReturnNullForInvalidParameters(Integer albumId, String username) {
+
+        // when
+        Instant actual = albumService.getAlbumStarredDate(albumId, username);
+
+        // then
+        assertNull(actual);
+        verifyNoInteractions(albumRepository, starredAlbumRepository);
     }
 
 }


### PR DESCRIPTION
Fix search3 starred album lookup

Avoid LazyInitializationException when serializing search3 album results by
reading the starred timestamp directly from StarredAlbumRepository instead of
accessing the lazy Album.starredAlbums collection.

Add a repository lookup by album id and username, remove the old AlbumRepository
association-based lookup, and update service/repository tests for the new
behavior.

Fixes: When client requests starred albums through search3

WARN --- o.a.player.filter.RESTFilter             : Error in REST API

org.hibernate.LazyInitializationException: failed to lazily initialize a collection of role: org.airsonic.player.domain.Album.starredAlbums: could not initialize proxy - no Sessionat org.hibernate.collection.spi.AbstractPersistentCollection.throwLazyInitializationException(AbstractPersistentCollection.java:635) ~[hibernate-core-6.6.49.Final.jar:6.6.49.Final]at org.hibernate.collection.spi.AbstractPersistentCollection.withTemporarySessionIfNeeded(AbstractPersistentCollection.java:219) ~[hibernate-core-6.6.49.Final.jar:6.6.49.Final]at org.hibernate.collection.spi.AbstractPersistentCollection.readSize(AbstractPersistentCollection.java:150) ~[hibernate-core-6.6.49.Final.jar:6.6.49.Final]at org.hibernate.collection.spi.PersistentBag.isEmpty(PersistentBag.java:358) ~[hibernate-core-6.6.49.Final.jar:6.6.49.Final]