### PR TITLE
fix(rest): fall back to album art for numeric cover ids

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/CoverArtController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/CoverArtController.java
@@ -170,7 +170,11 @@ public class CoverArtController {
         if (id.startsWith(PODCAST_COVERART_PREFIX)) {
             return coverArtCreateService.createPodcastCoverArtRequest(Integer.valueOf(id.replace(PODCAST_COVERART_PREFIX, "")), offset);
         }
-        return coverArtCreateService.createMediaFileCoverArtRequest(Integer.valueOf(id), offset);
+        Integer numericId = Integer.valueOf(id);
+        CoverArtRequest mediaFileCoverArtRequest = coverArtCreateService.createMediaFileCoverArtRequest(numericId, offset);
+        return mediaFileCoverArtRequest != null
+                ? mediaFileCoverArtRequest
+                : coverArtCreateService.createAlbumCoverArtRequest(numericId);
     }
 
 

--- a/airsonic-main/src/test/java/org/airsonic/player/controller/CoverArtControllerTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/controller/CoverArtControllerTest.java
@@ -182,6 +182,64 @@ public class CoverArtControllerTest {
 
     }
 
+    /** get cover art by numeric album id when no media file matches */
+    @Test
+    @WithMockUser(username = AIRSONIC_USER, password = AIRSONIC_PASSWORD)
+    public void getCoverArtWithIntegerAlbumFallbackTest() throws Exception {
+
+        final int ALBUM_ID = 100;
+
+        Album mockedAlbum = new Album();
+        mockedAlbum.setId(ALBUM_ID);
+        AlbumCoverArtRequest request = new AlbumCoverArtRequest(mockedCoverArt, mockedAlbum);
+
+        doReturn(null).when(coverArtService).createMediaFileCoverArtRequest(eq(ALBUM_ID), eq(60));
+        doReturn(request).when(coverArtService).createAlbumCoverArtRequest(eq(ALBUM_ID));
+        doReturn(IMAGE_RESOURCE.getFile().toPath()).when(mockedCoverArt).getFullPath();
+
+        byte[] expected = IMAGE_RESOURCE.getInputStream().readAllBytes();
+
+        byte[] actual = mvc.perform(get("/coverArt")
+                .param("id", Integer.toString(ALBUM_ID)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsByteArray();
+
+        assertArrayEquals(expected, actual);
+        verify(coverArtService).createMediaFileCoverArtRequest(eq(ALBUM_ID), eq(60));
+        verify(coverArtService).createAlbumCoverArtRequest(eq(ALBUM_ID));
+        verify(coverArtService).getImageInputStreamWithType(eq(IMAGE_RESOURCE.getFile().toPath()));
+        verifyNoMoreInteractions(coverArtService);
+    }
+
+    /** get fallback by numeric id when neither media file nor album matches */
+    @Test
+    @WithMockUser(username = AIRSONIC_USER, password = AIRSONIC_PASSWORD)
+    public void getCoverArtWithIntegerIdNoMatchFallbackTest() throws Exception {
+
+        final int MISSING_ID = 100;
+
+        doReturn(null).when(coverArtService).createMediaFileCoverArtRequest(eq(MISSING_ID), eq(60));
+        doReturn(null).when(coverArtService).createAlbumCoverArtRequest(eq(MISSING_ID));
+
+        byte[] actual = mvc.perform(get("/coverArt")
+                .param("id", Integer.toString(MISSING_ID)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsByteArray();
+
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            InputStream in = coverArtController.getClass().getResourceAsStream("default_cover.jpg");
+            BufferedImage image = ImageIO.read(in);
+            ImageIO.write(image, "jpeg", out);
+            byte[] expected = out.toByteArray();
+
+            assertArrayEquals(expected, actual);
+        }
+
+        verify(coverArtService).createMediaFileCoverArtRequest(eq(MISSING_ID), eq(60));
+        verify(coverArtService).createAlbumCoverArtRequest(eq(MISSING_ID));
+        verifyNoMoreInteractions(coverArtService);
+    }
+
     /** get cover art by id with album prerix "al-" */
     @Test
     @WithMockUser(username = AIRSONIC_USER, password = AIRSONIC_PASSWORD)


### PR DESCRIPTION
## Summary

This PR improves `getCoverArt` handling for REST clients that pass an album ID directly instead of the album `coverArt` value.

Bare numeric cover-art IDs now keep the existing media-file/folder behavior first. If no media-file cover request can be built, Airsonic falls back to resolving the same numeric ID as an album ID.

## Why

Some clients call:

```text
/rest/getCoverArt.view?id=<albumId>
```
instead of using:
```text
/rest/getCoverArt.view?id=al-<albumId>
```

Before this change, Airsonic treated the numeric value only as a media-file ID and could return the placeholder even when album artwork existed.

## Changes

Preserve prefixed cover-art IDs such as al-, ar-, pl-, and pod-.
Preserve media-file/folder precedence for bare numeric IDs.
Add album fallback when the numeric media-file/folder lookup fails.
Add controller tests for numeric album fallback and no-match placeholder behavior.